### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# board
+#
+# VERSION               1.0
+FROM golang:alpine
+
+ADD . /go/src/board
+WORKDIR /go/src/board
+
+RUN go build .
+
+EXPOSE 8080
+ENTRYPOINT ./board -p 8080


### PR DESCRIPTION
This pull request adds a Dockerfile for fast deployment from sources. It relies on an Alpine base image with Go installed. Tell me if you prefer another base image or if you'd prefer to install Go directly in the Dockerfile.

The web interface is exposed on port 8080.
