### PR TITLE
Rename sample config for highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+config.sample linguist-language=Go


### PR DESCRIPTION
A tiny pull request to add syntax highlighting to the sample config file by adding a `.go` file extension.
It does not matter much, although my first action was to consult the sample config file to get a sense of what configuring board involves and I guess other users might do the same.

An alternate way to get syntax highlighting would be to use a `.gitattribute` file with:

```
config.sample linguist-language=Go
```
