### PR TITLE
DNS Probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@
 # VERSION               1.0
 FROM golang:alpine
 
+RUN apk update
+RUN apk add git
+RUN go get github.com/miekg/dns
+RUN go build github.com/miekg/dns
+
 ADD . /go/src/board
 WORKDIR /go/src/board
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ Available probes
 func NewHTTP(addrport string, warning time.Duration, fatal time.Duration, regex string) *HTTP
 ```
 
+#### DNS
+
+```go
+// NewDNS returns a ready-to-go probe.
+// `domain` will be resolved through a lookup for an A record.
+// `expected` should be the first returned IPv4 address or empty to accept any IP address.
+// A warning will be triggered if the response takes more than `warning` to come.
+func NewDNS(addr, domain, expected string, warning, fatal time.Duration) *DNS
+```
+
 #### SMTP (over TLS)
 
 ```go

--- a/probe/dns.go
+++ b/probe/dns.go
@@ -1,0 +1,54 @@
+package probe
+
+import (
+	"github.com/miekg/dns"
+	"time"
+)
+
+// DNS Probe, used to check whether a DNS server is answering.
+type DNS struct {
+	addr, domain, expected  string
+	warning, fatal time.Duration
+}
+
+// NewDNS returns a ready-to-go probe.
+// `domain` will be resolved through a lookup for an A record.
+// `expected` should be the first returned IPv4 address or empty to accept any IP address.
+// A warning will be triggered if the response takes more than `warning` to come.
+func NewDNS(addr, domain, expected string, warning, fatal time.Duration) *DNS {
+	return &DNS{
+		addr:     addr,
+		domain:   domain,
+		expected: expected,
+		warning:  warning,
+		fatal:    fatal,
+	}
+}
+
+// Probe checks a DNS server.
+// If the operation succeeds, the message will be the duration of the dial in ms.
+// Otherwise, an error message is returned.
+func (d *DNS) Probe() (status Status, message string) {
+	m := new(dns.Msg)
+	m.SetQuestion(d.domain, dns.TypeA)
+
+	c := new(dns.Client)
+	r, rtt, err := c.Exchange(m, d.addr + ":53")
+	if err != nil {
+		return StatusError, err.Error()
+	}
+
+	if r.Rcode != dns.RcodeSuccess {
+		return StatusError, "Failed to resolve domain."
+	}
+
+	if answer, ok := r.Answer[0].(*dns.A); ok {
+		if d.expected != "" && answer.A.String() != d.expected {
+			return StatusError, "Unexpected DNS answer"
+		}
+	} else {
+		return StatusError, "Failed to resolve domain."
+	}
+
+	return EvaluateDuration(rtt, d.warning)
+}


### PR DESCRIPTION
I made a first quick implementation for a DNS probe. I'd like to clean it up and upstream it (that'd be my first Go implementation ever :smile: ), but first, I want to see with you how you think it should be exposed to the user.

It currently is exposed as:

``` go
func NewDNS(addrport string, warning, fatal time.Duration) *DNS
```

Should I also allow the user to change the tested domain (currently `A google.com`) and check the answer? Should we really expose the destination port as well?

Also, I use this Go library for the DNS client: https://github.com/miekg/dns. Do you have a better suggestion or is that fine?
