### PR TITLE
Insecure certificate with HTTP probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Available probes
 // NewHTTP returns a ready-to-go probe.
 // A warning will be triggered if the response takes more than `warning` to come.
 // The `regex` is used to check the content of the website, and can be empty.
-func NewHTTP(addrport string, warning time.Duration, fatal time.Duration, regex string) *HTTP
+// Set `verifyCertificate` to `false` to skip the certificate verification.
+func NewHTTP(addrport string, warning time.Duration, fatal time.Duration, regex string, verifyCertificate bool) *HTTP
 ```
 
 #### DNS

--- a/README.md
+++ b/README.md
@@ -45,9 +45,14 @@ Available probes
 ```go
 // NewHTTP returns a ready-to-go probe.
 // A warning will be triggered if the response takes more than `warning` to come.
-// The `regex` is used to check the content of the website, and can be empty.
-// Set `verifyCertificate` to `false` to skip the certificate verification.
-func NewHTTP(addrport string, warning time.Duration, fatal time.Duration, regex string, verifyCertificate bool) *HTTP
+func NewHTTP(addrport string, warning time.Duration, fatal time.Duration) *HTTP
+
+// NewCustomHTTP returns a ready-to-go probe.
+// A warning will be triggered if the response takes more than `warning` to come.
+// `opt` may contain two optional fields: `Regex` and `VerifyCertificate`.
+// The `Regex` is used to check the content of the website, and can be empty.
+// Set `VerifyCertificate` to `false` to skip the certificate verification.
+func NewCustomHTTP(addrport string, warning, fatal time.Duration, opt *HTTPParams) *HTTP {
 ```
 
 #### DNS

--- a/config.sample
+++ b/config.sample
@@ -8,16 +8,21 @@ import (
 	"time"
 )
 
+var opt = &probe.HTTPParams{
+	Regex:             "^<html>",
+	VerifyCertificate: true,
+}
+
 // M configures the available probes on the monitor, sorted by catgeories.
 var M = &Manager{
 	"Category Name": []*Service{
 		&Service{
 			Name:   "Service 1",
-			Prober: probe.NewHTTP("https://www.example.com", time.Second, 10*time.Second, ""),
+			Prober: probe.NewHTTP("https://www.example.com", time.Second, 10*time.Second),
 		},
 		&Service{
 			Name:   "Service 2",
-			Prober: probe.NewHTTP("http://sub.example.com", time.Second, 10*time.Second, "^<html>"),
+			Prober: probe.NewCustomHTTP("http://sub.example.com", time.Second, 10*time.Second, opt),
 		},
 	},
 }

--- a/probe/http.go
+++ b/probe/http.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 	"time"
+	"crypto/tls"
 )
 
 // HTTP Probe, used to check HTTP(S) websites status.
@@ -19,10 +20,15 @@ type HTTP struct {
 // NewHTTP returns a ready-to-go probe.
 // A warning will be triggered if the response takes more than `warning` to come.
 // The `regex` is used to check the content of the website, and can be empty.
-func NewHTTP(addrport string, warning, fatal time.Duration, regex string) *HTTP {
+// Set `verifyCertificate` to `false` to skip the certificate verification.
+func NewHTTP(addrport string, warning, fatal time.Duration, regex string, verifyCertificate bool) *HTTP {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyCertificate},
+	}
 	return &HTTP{
 		client: &http.Client{
-			Timeout: fatal,
+			Timeout:   fatal,
+			Transport: tr,
 		},
 		addrport: addrport,
 		warning:  warning,

--- a/probe/http_test.go
+++ b/probe/http_test.go
@@ -8,38 +8,44 @@ import (
 )
 
 func TestHTTPSuccess(t *testing.T) {
-	h := NewHTTP("https://www.lesterpig.com", 5*time.Second, 10*time.Second, "Loïck")
+	p := &HTTPParams{
+		Regex: "Loïck",
+	}
+	h := NewCustomHTTP("https://www.lesterpig.com", 5*time.Second, 10*time.Second, p)
 	s, m := h.Probe()
 	assert.True(t, StatusOK == s)
 	t.Log(m)
 }
 
 func TestHTTPWarning(t *testing.T) {
-	h := NewHTTP("https://www.lesterpig.com", time.Millisecond, 10*time.Second, "")
+	h := NewHTTP("https://www.lesterpig.com", time.Millisecond, 10*time.Second)
 	s, _ := h.Probe()
 	assert.True(t, StatusWarning == s)
 }
 
 func TestHTTP404(t *testing.T) {
-	h := NewHTTP("https://www.lesterpig.com/404", 5*time.Second, 10*time.Second, "")
+	h := NewHTTP("https://www.lesterpig.com/404", 5*time.Second, 10*time.Second)
 	s, _ := h.Probe()
 	assert.True(t, StatusError == s)
 }
 
 func TestHTTPError(t *testing.T) {
-	h := NewHTTP("https://www.leeesterpig.com", 5*time.Second, 10*time.Second, "")
+	h := NewHTTP("https://www.leeesterpig.com", 5*time.Second, 10*time.Second)
 	s, _ := h.Probe()
 	assert.True(t, StatusError == s)
 }
 
 func TestHTTPTimeout(t *testing.T) {
-	h := NewHTTP("https://www.lesterpig.com", time.Second, time.Millisecond, "")
+	h := NewHTTP("https://www.lesterpig.com", time.Second, time.Millisecond)
 	s, _ := h.Probe()
 	assert.True(t, StatusError == s)
 }
 
 func TestHTTPUnexpected(t *testing.T) {
-	h := NewHTTP("https://www.lesterpig.com", 5*time.Second, 10*time.Second, "Unexpected")
+	p := &HTTPParams{
+		Regex: "Unexpected",
+	}
+	h := NewCustomHTTP("https://www.lesterpig.com", 5*time.Second, 10*time.Second, p)
 	s, m := h.Probe()
 	assert.True(t, StatusError == s)
 	assert.True(t, "Unexpected result" == m)


### PR DESCRIPTION
Local websites often have self-signed certificates and fail the status check. This pull request makes it possible to skip the certificate verification via a new parameter to the `NewHTTP` call.

A future improvement of this pull request could be to take a certificate as a parameter.
