### PR TITLE
Check Go format in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go_import_path: board
+install:
+  - go get github.com/miekg/dns
+before_script:
+  - cp config.sample config.go
+script:
+  - gofmt -l . | [ `wc -l` == 0 ]
+  - go build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ FROM golang:alpine
 RUN apk update
 RUN apk add git
 RUN go get github.com/miekg/dns
-RUN go build github.com/miekg/dns
 
 ADD . /go/src/board
 WORKDIR /go/src/board

--- a/config.sample
+++ b/config.sample
@@ -3,7 +3,7 @@
 package main
 
 import (
-  "board/alert"
+	"board/alert"
 	"board/probe"
 	"time"
 )
@@ -24,5 +24,5 @@ var M = &Manager{
 
 // A is a slice of alerts that should be triggered when a service goes down.
 var A = []alert.Alerter{
-  alert.NewPushbullet("<your token here>"),
+	alert.NewPushbullet("<your token here>"),
 }

--- a/probe/dns.go
+++ b/probe/dns.go
@@ -7,8 +7,8 @@ import (
 
 // DNS Probe, used to check whether a DNS server is answering.
 type DNS struct {
-	addr, domain, expected  string
-	warning, fatal time.Duration
+	addr, domain, expected string
+	warning, fatal         time.Duration
 }
 
 // NewDNS returns a ready-to-go probe.
@@ -33,7 +33,7 @@ func (d *DNS) Probe() (status Status, message string) {
 	m.SetQuestion(d.domain, dns.TypeA)
 
 	c := new(dns.Client)
-	r, rtt, err := c.Exchange(m, d.addr + ":53")
+	r, rtt, err := c.Exchange(m, d.addr+":53")
 	if err != nil {
 		return StatusError, err.Error()
 	}


### PR DESCRIPTION
This pull request will ensure that the formatting errors from #4 don't happen again :-)
It adds a simple Travis build that looks for syntax (`go build`) and formatting (`gofmt`) errors.

I also fixed the formatting errors from #4 (6f416d7) and removed the unnecessary build step from the Dockerfile (64a9764).
