### PR TITLE
Embed static resources files to binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ go get github.com/lesterpig/board
 cp example.yaml board.yaml
 vim board.yaml
 ```
+
+Build single binary
+-------------------
+
+You may want to include the `/static/` directory as a ZIP resource in your binary.
+
+```
+go build -ldflags "-s -w" .
+rice append --exec board
+```
+
+Documentation: https://github.com/GeertJohan/go.rice#append

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strconv"
 	"time"
+
+	rice "github.com/GeertJohan/go.rice"
 )
 
 var port = flag.Int("p", 8080, "Port to use")
@@ -22,7 +24,7 @@ func main() {
 	}
 
 	// Setup static folder
-	http.Handle("/", http.FileServer(http.Dir("./static")))
+	http.Handle("/", http.FileServer(rice.MustFindBox("static").HTTPBox()))
 
 	// Setup logic route
 	http.HandleFunc("/data", func(w http.ResponseWriter, req *http.Request) {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -3,7 +3,7 @@
 body {
   background-color: #192823;
   color: white;
-  font-family: Verdana;
+  font-family: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
 }
 
 h1 {


### PR DESCRIPTION
No need to export the `/static` directory to deployments :+1: 